### PR TITLE
fixed css white part not continuing below page height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,7 @@ body {
   padding: 0% 5%;
   font-family: "Helvetica Neue", Helvetica, malgun gothic, Ubuntu, Arial, sans-serif;
   font-size: 16px;
-  height: 100%;
+  height: auto;
 }
 
 #top {


### PR DESCRIPTION
Now White css part containing all text properly extends below page height