### PR TITLE
Fix image size to not exceed container width

### DIFF
--- a/scss/src/_global.scss
+++ b/scss/src/_global.scss
@@ -90,3 +90,9 @@ ul {
 ul{
   padding-left: 1.1em;
 }
+
+img{
+  height: auto;
+  max-width: 100%;
+  width: auto;
+}


### PR DESCRIPTION
Update global.scss with changes to force images to play nicely and stay within their parent container's boundaries.

Specifically addresses the Verizon "al-a-carte" infographic being oversized in resolutions smaller than desktop.