### PR TITLE
reorder sections to put net neutrality and title 2 definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
     </div>
   </section>
 
-  <section id="net-neutrality" class="theme-blue">
+  <section id="net-neutrality">
       <div>
           <div>
               <h2>What is Net Neutrality and the Open Internet?</h2>
@@ -70,7 +70,7 @@
       </div>
   </section>
 
-  <section id="title_II" class="theme-light">
+  <section id="title_II" class="theme-blue">
       <div>
           <div>
               <h2>What is Title II?</h2>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,57 @@
       </div>
     </div>
   </section>
-  
+
+  <section id="net-neutrality" class="theme-blue">
+      <div>
+          <div>
+              <h2>What is Net Neutrality and the Open Internet?</h2>
+              <p>Net Neutrality is the internet's guiding principle: It preserves our right to communicate freely online. Net Neutrality means an internet that enables and protects free speech. It means that ISPs should provide us with open networks — and shouldn't
+                  block or discriminate against any applications or content that ride over those networks. Just as your phone company shouldn't decide who you call and what you say on that call, your ISP shouldn't interfere with the content you view or post online.
+                  Without Net Neutrality, cable and phone companies could carve the internet into fast and slow lanes. An ISP could slow down its competitors' content or block political opinions it disagreed with. ISPs could charge extra fees to the few content
+                  companies that could afford to pay for preferential treatment — relegating everyone else to a slower tier of service. This would destroy the open internet.
+
+                  <a href="https://www.savetheinternet.com/net-neutrality-what-you-need-know-now" rel="noopener noreferrer" target="_blank">savetheinternet.com</a>
+              </p>
+          </div>
+      </div>
+  </section>
+
+  <section id="title_II" class="theme-light">
+      <div>
+          <div>
+              <h2>What is Title II?</h2>
+              <p>Title II is part of the Communications Act of 1934. In essence, it prevents service providers from abusing customers. In 2015, an update to the Communications Act modernized the literature and reclassified ISPs under Title
+                  II as <a href="https://en.wikipedia.org/wiki/Common_carrier" rel="noopener noreferrer" target="_blank">"common carriers"</a>. This change gave the FCC oversight of ISPs, allowing them to ensure net neutrality, and even set
+                  prices for services provided by ISPs.</p>
+          </div>
+      </div>
+  </section>
+
+  <section id="implications" class="theme-dark">
+      <div>
+          <div>
+              <h2>What does all of this mean?</h2>
+              <p>If Pai's plans come to fruition, ISPs will no longer be regulated by the FCC. Instead, it will be up to the FTC to protect consumers (read "EVERYONE", including businesses!) from harmful business practices. ISPs have <a href="https://en.wikipedia.org/wiki/Net_neutrality#By_issue" rel="noopener noreferrer" target="_blank">actively fought net neutrality in the past</a>,
+                  and they're certain to continue.</p>
+              <p>Without FCC intervention, ISPs can block access to sites, extort companies for using more bandwidth than others, and cap and throttle network speeds for users - <i>and they have.</i></p>
+              <ul>
+                  <li>Madison River Communications blocked VOIP services. The FCC put a stop to it. <a href="https://www.cnet.com/news/telco-agrees-to-stop-blocking-voip-calls/" rel="noopener noreferrer" target="_blank">(2005)</a></li>
+                  <li>Comcast denied access to p2p services without notifying customers. <a href="https://www.eff.org/deeplinks/2007/10/eff-tests-agree-ap-comcast-forging-packets-to-interfere" target="_blank">(2005)</a></li>
+                  <li>AT&amp;T blocked Skype and other VOIPs because they didn't like the competition for their cellphone services. <a href="http://fortune.com/2009/04/03/group-asks-fcc-to-probe-iphone-skype-restrictions/" rel="noopener noreferrer" target="_blank">(2007)</a></li>
+                  <li>MetroPCS tried to block all streaming except YouTube. They actually sued the FCC over this. <a href="https://www.wired.com/2011/01/metropcs-net-neutrality-challenge/" rel="noopener noreferrer" target="_blank">(2011)</a></li>
+                  <li>AT&amp;T, Sprint, and Verizon blocked access to tethering apps on the Android marketplace, with Google's help. <a href="https://www.savetheinternet.com/blog/11/07/06/verizons-illegal-app-blocking" rel="noopener noreferrer" target="_blank">(2011)</a></li>
+                  <li>AT&amp;T, Sprint, and Verizon blocked access to Google Wallet because it competed with their payment apps. <a href="http://searchengineland.com/verizon-blocks-google-wallet-att-likely-to-do-the-same-103759" rel="noopener noreferrer" target="_blank">(2011)</a></li>
+                  <li>Verizon demanded Google block tethering apps on android because it let owners avoid their $20 tethering fee. This was despite guaranteeing they wouldn't do that as part of a winning bid on an airwaves auction. They were fined $1.25million over this. <a href="https://www.washingtonpost.com/blogs/post-tech/post/fcc-fines-verizon-125m-for-blocking-tethering-apps/2012/07/31/gJQAXjRLNX_blog.html?utm_term=.96359859e1ff" target="_blank">(2012)</a></li>
+                  <li>AT&amp;T tried to block access to FaceTime unless customers paid more money. <a href="https://www.freepress.net/press-release/99480/att-blocking-iphones-facetime-app-would-harm-consumers-and-break-net-neutrality" rel="noopener noreferrer" target="_blank">(2012)</a></li>
+                  <li>Verizon stated that the only thing stopping them from favoring some content providers over other providers were the net neutrality rules in place. <a href="https://www.savetheinternet.com/blog/2013/09/18/verizons-plan-break-internet" rel="noopener noreferrer" target="_blank">(2013)</a></li>
+                  <li>Time Warner Cable refused to upgrade their lines in order to get more money out of Riot Games (creators of League of Legends) and Netflix. <a href="https://www.polygon.com/2017/2/9/14548880/time-warner-lawsuit-new-york-league-of-legends-netflix" rel="noopener noreferrer" target="_blank">(2017)</a></li>
+              </ul>
+              <p><strong>We cannot allow this type of behavior to continue.</strong></p>
+          </div>
+      </div>
+  </section>
+
   <section id="get-involved" class="theme-red">
     <div>
       <div>
@@ -63,56 +113,6 @@
         <p>You can also send comments to through the EFF's "Dear FCC" website: <a href="https://dearfcc.org/" rel="noopener noreferrer" target="_blank">https://dearfcc.org/</a> </p>
         <p><strong>Call the FCC</strong> at: 1-888-CALL FCC (225-5322).</p>
         <p><strong>Contact your <a href="http://www.house.gov/representatives/find/" rel="noopener noreferrer" target="_blank">Representatives</a> and <a href="https://www.senate.gov/senators/contact/" rel="noopener noreferrer" target="_blank"> Senators</a>!</strong> Let them know Net Neutrality matters to you! Collectively we have a voice.</p>
-      </div>
-    </div>
-  </section>
-  
-  <section id="implications" class="theme-dark">
-    <div>
-      <div>
-        <h2>What does all of this mean?</h2>
-        <p>If Pai's plans come to fruition, ISPs will no longer be regulated by the FCC. Instead, it will be up to the FTC to protect consumers (read "EVERYONE", including businesses!) from harmful business practices. ISPs have <a href="https://en.wikipedia.org/wiki/Net_neutrality#By_issue" rel="noopener noreferrer" target="_blank">actively fought net neutrality in the past</a>,
-          and they're certain to continue.</p>
-        <p>Without FCC intervention, ISPs can block access to sites, extort companies for using more bandwidth than others, and cap and throttle network speeds for users - <i>and they have.</i></p>
-        <ul>
-          <li>Madison River Communications blocked VOIP services. The FCC put a stop to it. <a href="https://www.cnet.com/news/telco-agrees-to-stop-blocking-voip-calls/" rel="noopener noreferrer" target="_blank">(2005)</a></li>
-          <li>Comcast denied access to p2p services without notifying customers. <a href="https://www.eff.org/deeplinks/2007/10/eff-tests-agree-ap-comcast-forging-packets-to-interfere" target="_blank">(2005)</a></li>
-          <li>AT&amp;T blocked Skype and other VOIPs because they didn't like the competition for their cellphone services. <a href="http://fortune.com/2009/04/03/group-asks-fcc-to-probe-iphone-skype-restrictions/" rel="noopener noreferrer" target="_blank">(2007)</a></li>
-          <li>MetroPCS tried to block all streaming except YouTube. They actually sued the FCC over this. <a href="https://www.wired.com/2011/01/metropcs-net-neutrality-challenge/" rel="noopener noreferrer" target="_blank">(2011)</a></li>
-          <li>AT&amp;T, Sprint, and Verizon blocked access to tethering apps on the Android marketplace, with Google's help. <a href="https://www.savetheinternet.com/blog/11/07/06/verizons-illegal-app-blocking" rel="noopener noreferrer" target="_blank">(2011)</a></li>
-          <li>AT&amp;T, Sprint, and Verizon blocked access to Google Wallet because it competed with their payment apps. <a href="http://searchengineland.com/verizon-blocks-google-wallet-att-likely-to-do-the-same-103759" rel="noopener noreferrer" target="_blank">(2011)</a></li>
-          <li>Verizon demanded Google block tethering apps on android because it let owners avoid their $20 tethering fee. This was despite guaranteeing they wouldn't do that as part of a winning bid on an airwaves auction. They were fined $1.25million over this. <a href="https://www.washingtonpost.com/blogs/post-tech/post/fcc-fines-verizon-125m-for-blocking-tethering-apps/2012/07/31/gJQAXjRLNX_blog.html?utm_term=.96359859e1ff" target="_blank">(2012)</a></li>
-          <li>AT&amp;T tried to block access to FaceTime unless customers paid more money. <a href="https://www.freepress.net/press-release/99480/att-blocking-iphones-facetime-app-would-harm-consumers-and-break-net-neutrality" rel="noopener noreferrer" target="_blank">(2012)</a></li>
-          <li>Verizon stated that the only thing stopping them from favoring some content providers over other providers were the net neutrality rules in place. <a href="https://www.savetheinternet.com/blog/2013/09/18/verizons-plan-break-internet" rel="noopener noreferrer" target="_blank">(2013)</a></li>
-          <li>Time Warner Cable refused to upgrade their lines in order to get more money out of Riot Games (creators of League of Legends) and Netflix. <a href="https://www.polygon.com/2017/2/9/14548880/time-warner-lawsuit-new-york-league-of-legends-netflix" rel="noopener noreferrer" target="_blank">(2017)</a></li>
-        </ul>
-        <p><strong>We cannot allow this type of behavior to continue.</strong></p>
-      </div>
-    </div>
-  </section>
-  
-  <section id="title_II" class="theme-blue">
-    <div>
-      <div>
-        <h2>What is Title II?</h2>
-        <p>Title II is part of the Communications Act of 1934. In essence, it prevents service providers from abusing customers. In 2015, an update to the Communications Act modernized the literature and reclassified ISPs under Title
-          II as <a href="https://en.wikipedia.org/wiki/Common_carrier" rel="noopener noreferrer" target="_blank">"common carriers"</a>. This change gave the FCC oversight of ISPs, allowing them to ensure net neutrality, and even set
-          prices for services provided by ISPs.</p>
-      </div>
-    </div>
-  </section>
-  
-  <section id="net-neutrality" class="theme-light">
-    <div>
-      <div>
-        <h2>What is Net Neutrality and the Open Internet?</h2>
-        <p>Net Neutrality is the internet's guiding principle: It preserves our right to communicate freely online. Net Neutrality means an internet that enables and protects free speech. It means that ISPs should provide us with open networks — and shouldn't
-          block or discriminate against any applications or content that ride over those networks. Just as your phone company shouldn't decide who you call and what you say on that call, your ISP shouldn't interfere with the content you view or post online.
-          Without Net Neutrality, cable and phone companies could carve the internet into fast and slow lanes. An ISP could slow down its competitors' content or block political opinions it disagreed with. ISPs could charge extra fees to the few content
-          companies that could afford to pay for preferential treatment — relegating everyone else to a slower tier of service. This would destroy the open internet.
-
-          <a href="https://www.savetheinternet.com/net-neutrality-what-you-need-know-now" rel="noopener noreferrer" target="_blank">savetheinternet.com</a>
-        </p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
I think it's a good idea to define net neutrality as early as possible. That way when we show Pai's intentions, people will know exactly what's at stake. They'll know this isn't just about letting corporations have the freedom to create the services they want, it's about preserving everyone's freedom to access information.